### PR TITLE
Fix: missing await on a few test expectations

### DIFF
--- a/test/1_Quartz.test.js
+++ b/test/1_Quartz.test.js
@@ -146,7 +146,7 @@ describe('Quartz', () => {
         .stake(amount, beneficiary.address, period);
       const currentTime = await getCurrentTime();
       const currentBlock = await getCurrentBlock();
-      expect(tx)
+      await expect(tx)
         .to.emit(quartz, 'Staked')
         .withArgs(
           '0',
@@ -170,14 +170,14 @@ describe('Quartz', () => {
       expect(stakeInfo.maturationTimestamp).equal(currentTime.add(period));
       expect(stakeInfo.active).equal(true);
 
-      expect(tx)
+      await expect(tx)
         .to.emit(quartz, 'DelegateChanged')
         .withArgs(
           beneficiary.address,
           constants.ZERO_ADDRESS,
           beneficiary.address,
         );
-      expect(tx)
+      await expect(tx)
         .to.emit(quartz, 'DelegateVotesChanged')
         .withArgs(beneficiary.address, '0', amount);
       expect(await quartz.userVotesRep(beneficiary.address)).equal(amount);
@@ -207,7 +207,7 @@ describe('Quartz', () => {
 
       const currentTime2 = await getCurrentTime();
       const currentBlock2 = await getCurrentBlock();
-      expect(tx)
+      await expect(tx)
         .to.emit(quartz, 'Staked')
         .withArgs(
           '1',
@@ -231,7 +231,7 @@ describe('Quartz', () => {
       expect(stakeInfo.maturationTimestamp).equal(currentTime2.add(period2));
       expect(stakeInfo.active).equal(true);
 
-      expect(tx)
+      await expect(tx)
         .to.emit(quartz, 'DelegateVotesChanged')
         .withArgs(beneficiary.address, amount, amount.add(amount2));
       expect(await quartz.userVotesRep(beneficiary.address)).equal(
@@ -267,7 +267,7 @@ describe('Quartz', () => {
 
       const currentTime2 = await getCurrentTime();
       const currentBlock2 = await getCurrentBlock();
-      expect(tx2)
+      await expect(tx2)
         .to.emit(quartz, 'Staked')
         .withArgs(
           '1',
@@ -299,7 +299,7 @@ describe('Quartz', () => {
       expect(stakeInfo.maturationTimestamp).equal(currentTime2.add(period2));
       expect(stakeInfo.active).equal(true);
 
-      expect(tx2)
+      await expect(tx2)
         .to.emit(quartz, 'DelegateVotesChanged')
         .withArgs(beneficiary2.address, '0', amount2);
       expect(await quartz.userVotesRep(beneficiary.address)).equal(amount);
@@ -331,7 +331,7 @@ describe('Quartz', () => {
         .stake(amount, beneficiary.address, period);
       const currentTime = await getCurrentTime();
       const currentBlock = await getCurrentBlock();
-      expect(tx)
+      await expect(tx)
         .to.emit(quartz, 'Staked')
         .withArgs(
           '0',
@@ -355,14 +355,14 @@ describe('Quartz', () => {
       expect(stakeInfo.maturationTimestamp).equal(currentTime.add(period));
       expect(stakeInfo.active).equal(true);
 
-      expect(tx)
+      await expect(tx)
         .to.emit(quartz, 'DelegateChanged')
         .withArgs(
           beneficiary.address,
           constants.ZERO_ADDRESS,
           beneficiary.address,
         );
-      expect(tx)
+      await expect(tx)
         .to.emit(quartz, 'DelegateVotesChanged')
         .withArgs(beneficiary.address, '0', amount);
       expect(await quartz.userVotesRep(beneficiary.address)).equal(amount);
@@ -387,7 +387,7 @@ describe('Quartz', () => {
         .stake(amount, beneficiary.address, period);
       const currentTime = await getCurrentTime();
       const currentBlock = await getCurrentBlock();
-      expect(tx)
+      await expect(tx)
         .to.emit(quartz, 'Staked')
         .withArgs(
           '0',
@@ -411,7 +411,7 @@ describe('Quartz', () => {
       expect(stakeInfo.maturationTimestamp).equal(currentTime.add(period));
       expect(stakeInfo.active).equal(true);
 
-      expect(tx)
+      await expect(tx)
         .to.emit(quartz, 'DelegateVotesChanged')
         .withArgs(delegatee.address, '0', amount);
       expect(await quartz.userVotesRep(beneficiary.address)).equal(amount);
@@ -477,7 +477,7 @@ describe('Quartz', () => {
       await time.increase(period.toString());
       const tx = await quartz.connect(sender).unstake('0');
       const unstakedBlock = await getCurrentBlock();
-      expect(tx)
+      await expect(tx)
         .to.emit(quartz, 'Unstaked')
         .withArgs('0', sender.address, beneficiary.address, amount);
       expect(await quartz.balanceOf(quartz.address)).equal('0');
@@ -491,7 +491,7 @@ describe('Quartz', () => {
       expect(stakeInfo.amount).equal(amount);
       expect(stakeInfo.active).equal(false);
 
-      expect(tx)
+      await expect(tx)
         .to.emit(quartz, 'DelegateVotesChanged')
         .withArgs(beneficiary.address, amount, '0');
       expect(await quartz.userVotesRep(beneficiary.address)).equal('0');
@@ -549,7 +549,7 @@ describe('Quartz', () => {
       expect(await quartz.delegates(accounts[2].address)).equal(
         delegatee.address,
       );
-      expect(tx)
+      await expect(tx)
         .to.emit(quartz, 'DelegateChanged')
         .withArgs(
           accounts[2].address,
@@ -561,7 +561,7 @@ describe('Quartz', () => {
       expect(await quartz.delegates(accounts[2].address)).equal(
         newDelegatee.address,
       );
-      expect(tx)
+      await expect(tx)
         .to.emit(quartz, 'DelegateChanged')
         .withArgs(accounts[2].address, delegatee.address, newDelegatee.address);
     });
@@ -589,7 +589,7 @@ describe('Quartz', () => {
         .connect(beneficiary)
         .delegate(delegatee.address);
       let delegateBlock = await getCurrentBlock();
-      expect(delegateTx)
+      await expect(delegateTx)
         .to.emit(quartz, 'DelegateChanged')
         .withArgs(beneficiary.address, beneficiary.address, delegatee.address);
 

--- a/test/2_QuartzGovernor.test.js
+++ b/test/2_QuartzGovernor.test.js
@@ -167,7 +167,7 @@ describe('QuartzGovernor', () => {
           newProposalThreshold,
           newProposalActivePeriod,
         );
-      expect(tx)
+      await expect(tx)
         .to.emit(governor, 'ConvictionSettingsChanged')
         .withArgs(
           newDecay,
@@ -221,7 +221,7 @@ describe('QuartzGovernor', () => {
       expect(await quartz.getCurrentVotes(governor.address)).equal(
         proposalThreshold,
       );
-      // expect(tx)
+      // await expect(tx)
       //   .to.emit(governor, 'ProposalAdded')
       //   .withArgs(
       //     proposalSubmitter.address,
@@ -294,7 +294,7 @@ describe('QuartzGovernor', () => {
 
     it('Proposal submitter can cancel', async () => {
       const tx = await governor.connect(proposalSubmitter).cancelProposal('2');
-      expect(tx).to.emit(governor, 'ProposalCancelled').withArgs(2);
+      await expect(tx).to.emit(governor, 'ProposalCancelled').withArgs(2);
       expect(await governor.lastVoteId()).equal(4);
 
       const proposal = await governor.getProposal('2');
@@ -310,7 +310,7 @@ describe('QuartzGovernor', () => {
       const tx = await governor
         .connect(cancelProposalsRole)
         .cancelProposal('2');
-      expect(tx).to.emit(governor, 'ProposalCancelled').withArgs(2);
+      await expect(tx).to.emit(governor, 'ProposalCancelled').withArgs(2);
       expect(await governor.lastVoteId()).equal(4);
 
       const proposal = await governor.getProposal('2');
@@ -325,7 +325,7 @@ describe('QuartzGovernor', () => {
     it('Anyone can cancel after expiration', async () => {
       await time.increase(proposalActivePeriod + 1);
       const tx = await governor.connect(accounts[8]).cancelProposal('2');
-      expect(tx).to.emit(governor, 'ProposalCancelled').withArgs(2);
+      await expect(tx).to.emit(governor, 'ProposalCancelled').withArgs(2);
       expect(await governor.lastVoteId()).equal(4);
 
       const proposal = await governor.getProposal('2');
@@ -432,7 +432,7 @@ describe('QuartzGovernor', () => {
         await governor.calculateConviction(increaseBlock + 1, '0', votesToCast),
       );
       const tx = await governor.connect(accounts[1]).executeProposal('2');
-      expect(tx)
+      await expect(tx)
         .to.emit(governor, 'ProposalExecuted')
         .withArgs('2', conviction, '0');
       const proposal = await governor.getProposal('2');
@@ -532,7 +532,7 @@ describe('QuartzGovernor', () => {
       const tx = await governor
         .connect(beneficiary)
         .castVotes('2', votesToCast, true);
-      expect(tx)
+      await expect(tx)
         .to.emit(governor, 'VoteCasted')
         .withArgs(beneficiary.address, '2', votesToCast, '0', true);
       const currentBlock = await getCurrentBlock();
@@ -560,7 +560,7 @@ describe('QuartzGovernor', () => {
       const tx = await governor
         .connect(beneficiary)
         .castVotes('2', votesToCast, false);
-      expect(tx)
+      await expect(tx)
         .to.emit(governor, 'VoteCasted')
         .withArgs(beneficiary.address, '2', votesToCast, '0', false);
       const currentBlock = await getCurrentBlock();
@@ -598,7 +598,7 @@ describe('QuartzGovernor', () => {
         .connect(beneficiary)
         .castVotes('2', votesToCast1, true);
       const currentBlock = await getCurrentBlock();
-      expect(tx)
+      await expect(tx)
         .to.emit(governor, 'VoteCasted')
         .withArgs(beneficiary.address, '2', votesToCast1, conviction, true);
       expect(await governor.userVotes(3, beneficiary.address)).equal(
@@ -734,7 +734,7 @@ describe('QuartzGovernor', () => {
         .connect(beneficiary)
         .withdrawVotes('2', votesToWithdraw, true);
 
-      expect(tx)
+      await expect(tx)
         .to.emit(governor, 'VoteWithdrawn')
         .withArgs(beneficiary.address, '2', votesToWithdraw, conviction, true);
       const currentBlock = await getCurrentBlock();
@@ -774,7 +774,7 @@ describe('QuartzGovernor', () => {
         .connect(beneficiary)
         .withdrawAllVotesFromProposal('2', true);
 
-      expect(tx)
+      await expect(tx)
         .to.emit(governor, 'VoteWithdrawn')
         .withArgs(beneficiary.address, '2', votesToCast, conviction, true);
       const currentBlock = await getCurrentBlock();


### PR DESCRIPTION
Docs for `expect(...).to.emit()`: https://ethereum-waffle.readthedocs.io/en/latest/matchers.html#emitting-events

This is one of the possible reasons why some test suites have been randomly failing on CI. such as https://github.com/sandclock-org/sandclock-token/runs/4000685459?check_suite_focus=true