### PR TITLE
remove unused event argument

### DIFF
--- a/contracts/Quartz.sol
+++ b/contracts/Quartz.sol
@@ -31,11 +31,7 @@ contract Quartz is
         address indexed fromDelegate,
         address indexed toDelegate
     );
-    event DelegateVotesChanged(
-        address indexed delegate,
-        uint256 previousBalance,
-        uint256 newBalance
-    );
+    event DelegateVotesChanged(address indexed delegate, uint256 newBalance);
     event GovernorChanged(address indexed governor);
     event MinStakePeriodChanged(uint64 minStakePeriod);
 
@@ -254,7 +250,7 @@ contract Quartz is
                         : 0;
                 }
                 uint256 srcRepNew = srcRepOld - amount;
-                _writeCheckpoint(srcRep, srcRepNum, srcRepOld, srcRepNew);
+                _writeCheckpoint(srcRep, srcRepNum, srcRepNew);
             }
 
             if (dstRep != address(0)) {
@@ -264,7 +260,7 @@ contract Quartz is
                         ? checkpoints[dstRep][dstRepNum - 1].votes
                         : 0;
                 uint256 dstRepNew = dstRepOld + amount;
-                _writeCheckpoint(dstRep, dstRepNum, dstRepOld, dstRepNew);
+                _writeCheckpoint(dstRep, dstRepNum, dstRepNew);
             }
         }
     }
@@ -272,7 +268,6 @@ contract Quartz is
     function _writeCheckpoint(
         address delegatee,
         uint32 nCheckpoints,
-        uint256 oldVotes,
         uint256 newVotes
     ) internal {
         uint32 blockNumber =
@@ -294,7 +289,7 @@ contract Quartz is
             numCheckpoints[delegatee] = nCheckpoints + 1;
         }
 
-        emit DelegateVotesChanged(delegatee, oldVotes, newVotes);
+        emit DelegateVotesChanged(delegatee, newVotes);
     }
 
     function safe32(uint256 n, string memory errorMessage)

--- a/test/1_Quartz.test.js
+++ b/test/1_Quartz.test.js
@@ -217,7 +217,7 @@ describe('Quartz', () => {
         );
       await expect(tx)
         .to.emit(quartz, 'DelegateVotesChanged')
-        .withArgs(beneficiary.address, '0', amount);
+        .withArgs(beneficiary.address, amount);
       expect(await quartz.userVotesRep(beneficiary.address)).equal(amount);
       expect(await quartz.delegates(beneficiary.address)).equal(
         beneficiary.address,
@@ -271,7 +271,7 @@ describe('Quartz', () => {
 
       await expect(tx)
         .to.emit(quartz, 'DelegateVotesChanged')
-        .withArgs(beneficiary.address, amount, amount.add(amount2));
+        .withArgs(beneficiary.address, amount.add(amount2));
       expect(await quartz.userVotesRep(beneficiary.address)).equal(
         amount.add(amount2),
       );
@@ -339,7 +339,7 @@ describe('Quartz', () => {
 
       await expect(tx2)
         .to.emit(quartz, 'DelegateVotesChanged')
-        .withArgs(beneficiary2.address, '0', amount2);
+        .withArgs(beneficiary2.address, amount2);
       expect(await quartz.userVotesRep(beneficiary.address)).equal(amount);
       expect(await quartz.userVotesRep(beneficiary2.address)).equal(amount2);
       expect(await quartz.delegates(beneficiary.address)).equal(
@@ -402,7 +402,7 @@ describe('Quartz', () => {
         );
       await expect(tx)
         .to.emit(quartz, 'DelegateVotesChanged')
-        .withArgs(beneficiary.address, '0', amount);
+        .withArgs(beneficiary.address, amount);
       expect(await quartz.userVotesRep(beneficiary.address)).equal(amount);
       expect(await quartz.delegates(beneficiary.address)).equal(
         beneficiary.address,
@@ -451,7 +451,7 @@ describe('Quartz', () => {
 
       await expect(tx)
         .to.emit(quartz, 'DelegateVotesChanged')
-        .withArgs(delegatee.address, '0', amount);
+        .withArgs(delegatee.address, amount);
       expect(await quartz.userVotesRep(beneficiary.address)).equal(amount);
       expect(await quartz.delegates(beneficiary.address)).equal(
         delegatee.address,
@@ -538,7 +538,7 @@ describe('Quartz', () => {
 
       await expect(tx)
         .to.emit(quartz, 'DelegateVotesChanged')
-        .withArgs(beneficiary.address, amount, '0');
+        .withArgs(beneficiary.address, '0');
       expect(await quartz.userVotesRep(beneficiary.address)).equal('0');
       expect(await quartz.delegates(beneficiary.address)).equal(
         beneficiary.address,


### PR DESCRIPTION
DelegateVotesChanged event had unnecessary argument which indicates old balance.
We decided to remove it.